### PR TITLE
Update Dockerfile and Dockerfile32 to fix issue with Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM redis:latest
 
 RUN apt-get update -yq \
    && apt-get install curl gnupg -yq \
-   && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+   && curl -sL https://deb.nodesource.com/setup_12.x | bash \
    && apt-get install nodejs -yq \
    && apt-get install -y procps \
    && apt-get clean -y

--- a/Dockerfile.32bit
+++ b/Dockerfile.32bit
@@ -18,7 +18,7 @@ FROM redis:latest
 
 RUN apt-get update -yq \
    && apt-get install curl gnupg -yq \
-   && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+   && curl -sL https://deb.nodesource.com/setup_12.x | bash \
    && apt-get install nodejs -yq \
    && apt-get install -y procps \
    && apt-get clean -y


### PR DESCRIPTION
Hey there! I made some changes to address an issue we were facing with building the Docker composer. The problem was that Node.js 10.x is no longer supported, so I updated it to the latest release (12.x). This should resolve the issue. Please, test it and merge it.